### PR TITLE
Automated cherry

### DIFF
--- a/modules/effects/spec/effect_creator.spec.ts
+++ b/modules/effects/spec/effect_creator.spec.ts
@@ -52,30 +52,32 @@ describe('createEffect()', () => {
         a = createEffect(() => of({ type: 'a' }));
         b = createEffect(() => of({ type: 'b' }), { dispatch: true });
         c = createEffect(() => of({ type: 'c' }), { dispatch: false });
-        d = createEffect(() => of({ type: 'd' }), { resubscribeOnError: true });
+        d = createEffect(() => of({ type: 'd' }), {
+          useEffectsErrorHandler: true,
+        });
         e = createEffect(() => of({ type: 'd' }), {
-          resubscribeOnError: false,
+          useEffectsErrorHandler: false,
         });
         f = createEffect(() => of({ type: 'e' }), {
           dispatch: false,
-          resubscribeOnError: false,
+          useEffectsErrorHandler: false,
         });
         g = createEffect(() => of({ type: 'e' }), {
           dispatch: true,
-          resubscribeOnError: false,
+          useEffectsErrorHandler: false,
         });
       }
 
       const mock = new Fixture();
 
       expect(getCreateEffectMetadata(mock)).toEqual([
-        { propertyName: 'a', dispatch: true, resubscribeOnError: true },
-        { propertyName: 'b', dispatch: true, resubscribeOnError: true },
-        { propertyName: 'c', dispatch: false, resubscribeOnError: true },
-        { propertyName: 'd', dispatch: true, resubscribeOnError: true },
-        { propertyName: 'e', dispatch: true, resubscribeOnError: false },
-        { propertyName: 'f', dispatch: false, resubscribeOnError: false },
-        { propertyName: 'g', dispatch: true, resubscribeOnError: false },
+        { propertyName: 'a', dispatch: true, useEffectsErrorHandler: true },
+        { propertyName: 'b', dispatch: true, useEffectsErrorHandler: true },
+        { propertyName: 'c', dispatch: false, useEffectsErrorHandler: true },
+        { propertyName: 'd', dispatch: true, useEffectsErrorHandler: true },
+        { propertyName: 'e', dispatch: true, useEffectsErrorHandler: false },
+        { propertyName: 'f', dispatch: false, useEffectsErrorHandler: false },
+        { propertyName: 'g', dispatch: true, useEffectsErrorHandler: false },
       ]);
     });
 

--- a/modules/effects/spec/effect_decorator.spec.ts
+++ b/modules/effects/spec/effect_decorator.spec.ts
@@ -9,26 +9,26 @@ describe('@Effect()', () => {
         b: any;
         @Effect({ dispatch: false })
         c: any;
-        @Effect({ resubscribeOnError: true })
+        @Effect({ useEffectsErrorHandler: true })
         d: any;
-        @Effect({ resubscribeOnError: false })
+        @Effect({ useEffectsErrorHandler: false })
         e: any;
-        @Effect({ dispatch: false, resubscribeOnError: false })
+        @Effect({ dispatch: false, useEffectsErrorHandler: false })
         f: any;
-        @Effect({ dispatch: true, resubscribeOnError: false })
+        @Effect({ dispatch: true, useEffectsErrorHandler: false })
         g: any;
       }
 
       const mock = new Fixture();
 
       expect(getEffectDecoratorMetadata(mock)).toEqual([
-        { propertyName: 'a', dispatch: true, resubscribeOnError: true },
-        { propertyName: 'b', dispatch: true, resubscribeOnError: true },
-        { propertyName: 'c', dispatch: false, resubscribeOnError: true },
-        { propertyName: 'd', dispatch: true, resubscribeOnError: true },
-        { propertyName: 'e', dispatch: true, resubscribeOnError: false },
-        { propertyName: 'f', dispatch: false, resubscribeOnError: false },
-        { propertyName: 'g', dispatch: true, resubscribeOnError: false },
+        { propertyName: 'a', dispatch: true, useEffectsErrorHandler: true },
+        { propertyName: 'b', dispatch: true, useEffectsErrorHandler: true },
+        { propertyName: 'c', dispatch: false, useEffectsErrorHandler: true },
+        { propertyName: 'd', dispatch: true, useEffectsErrorHandler: true },
+        { propertyName: 'e', dispatch: true, useEffectsErrorHandler: false },
+        { propertyName: 'f', dispatch: false, useEffectsErrorHandler: false },
+        { propertyName: 'g', dispatch: true, useEffectsErrorHandler: false },
       ]);
     });
 

--- a/modules/effects/spec/effects_error_handler.spec.ts
+++ b/modules/effects/spec/effects_error_handler.spec.ts
@@ -1,0 +1,100 @@
+import { ErrorHandler, Provider } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Action, Store } from '@ngrx/store';
+import { Observable, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import { createEffect, EFFECTS_ERROR_HANDLER, EffectsModule } from '..';
+
+describe('Effects Error Handler', () => {
+  let subscriptionCount: number;
+  let globalErrorHandler: jasmine.Spy;
+  let storeNext: jasmine.Spy;
+
+  function makeEffectTestBed(...providers: Provider[]) {
+    subscriptionCount = 0;
+
+    TestBed.configureTestingModule({
+      imports: [EffectsModule.forRoot([ErrorEffect])],
+      providers: [
+        {
+          provide: Store,
+          useValue: {
+            next: jasmine.createSpy('storeNext'),
+            dispatch: jasmine.createSpy('dispatch'),
+          },
+        },
+        {
+          provide: ErrorHandler,
+          useValue: {
+            handleError: jasmine.createSpy('globalErrorHandler'),
+          },
+        },
+        ...providers,
+      ],
+    });
+
+    globalErrorHandler = TestBed.get(ErrorHandler).handleError;
+    const store = TestBed.get(Store);
+    storeNext = store.next;
+  }
+
+  it('should retry and notify error handler when effect error handler is not provided', () => {
+    makeEffectTestBed();
+
+    // two subscriptions expected:
+    // 1. Initial subscription to the effect (this will error)
+    // 2. Resubscription to the effect after error (this will not error)
+    expect(subscriptionCount).toBe(2);
+    expect(globalErrorHandler).toHaveBeenCalledWith(new Error('effectError'));
+  });
+
+  it('should use custom error behavior when EFFECTS_ERROR_HANDLER is provided', () => {
+    const effectsErrorHandlerSpy = jasmine
+      .createSpy()
+      .and.callFake((effect$: Observable<any>, errorHandler: ErrorHandler) => {
+        return effect$.pipe(
+          catchError(err => {
+            errorHandler.handleError(
+              new Error('inside custom handler: ' + err.message)
+            );
+            return of({ type: 'custom action' });
+          })
+        );
+      });
+
+    makeEffectTestBed({
+      provide: EFFECTS_ERROR_HANDLER,
+      useValue: effectsErrorHandlerSpy,
+    });
+
+    expect(effectsErrorHandlerSpy).toHaveBeenCalledWith(
+      jasmine.any(Observable),
+      TestBed.get(ErrorHandler)
+    );
+    expect(globalErrorHandler).toHaveBeenCalledWith(
+      new Error('inside custom handler: effectError')
+    );
+    expect(subscriptionCount).toBe(1);
+    expect(storeNext).toHaveBeenCalledWith({ type: 'custom action' });
+  });
+
+  class ErrorEffect {
+    effect$ = createEffect(errorFirstSubscriber, {
+      useEffectsErrorHandler: true,
+    });
+  }
+
+  /**
+   * This observable factory returns an observable that will never emit, but the first subscriber will get an immediate
+   * error. All subsequent subscribers will just get an observable that does not emit.
+   */
+  function errorFirstSubscriber(): Observable<Action> {
+    return new Observable(observer => {
+      subscriptionCount++;
+
+      if (subscriptionCount === 1) {
+        observer.error(new Error('effectError'));
+      }
+    });
+  }
+});

--- a/modules/effects/spec/effects_metadata.spec.ts
+++ b/modules/effects/spec/effects_metadata.spec.ts
@@ -12,18 +12,18 @@ describe('Effects metadata', () => {
         @Effect({ dispatch: false })
         c: any;
         d = createEffect(() => of({ type: 'a' }), { dispatch: false });
-        @Effect({ dispatch: false, resubscribeOnError: false })
+        @Effect({ dispatch: false, useEffectsErrorHandler: false })
         e: any;
         z: any;
       }
 
       const mock = new Fixture();
       const expected: EffectMetadata<Fixture>[] = [
-        { propertyName: 'a', dispatch: true, resubscribeOnError: true },
-        { propertyName: 'c', dispatch: false, resubscribeOnError: true },
-        { propertyName: 'b', dispatch: true, resubscribeOnError: true },
-        { propertyName: 'd', dispatch: false, resubscribeOnError: true },
-        { propertyName: 'e', dispatch: false, resubscribeOnError: false },
+        { propertyName: 'a', dispatch: true, useEffectsErrorHandler: true },
+        { propertyName: 'c', dispatch: false, useEffectsErrorHandler: true },
+        { propertyName: 'b', dispatch: true, useEffectsErrorHandler: true },
+        { propertyName: 'd', dispatch: false, useEffectsErrorHandler: true },
+        { propertyName: 'e', dispatch: false, useEffectsErrorHandler: false },
       ];
 
       expect(getSourceMetadata(mock)).toEqual(
@@ -45,20 +45,20 @@ describe('Effects metadata', () => {
         e: any;
         f = createEffect(() => of({ type: 'f' }), { dispatch: false });
         g = createEffect(() => of({ type: 'g' }), {
-          resubscribeOnError: false,
+          useEffectsErrorHandler: false,
         });
       }
 
       const mock = new Fixture();
 
       expect(getEffectsMetadata(mock)).toEqual({
-        a: { dispatch: true, resubscribeOnError: true },
-        c: { dispatch: true, resubscribeOnError: true },
-        e: { dispatch: false, resubscribeOnError: true },
-        b: { dispatch: true, resubscribeOnError: true },
-        d: { dispatch: true, resubscribeOnError: true },
-        f: { dispatch: false, resubscribeOnError: true },
-        g: { dispatch: true, resubscribeOnError: false },
+        a: { dispatch: true, useEffectsErrorHandler: true },
+        c: { dispatch: true, useEffectsErrorHandler: true },
+        e: { dispatch: false, useEffectsErrorHandler: true },
+        b: { dispatch: true, useEffectsErrorHandler: true },
+        d: { dispatch: true, useEffectsErrorHandler: true },
+        f: { dispatch: false, useEffectsErrorHandler: true },
+        g: { dispatch: true, useEffectsErrorHandler: false },
       });
     });
 

--- a/modules/effects/src/effect_creator.ts
+++ b/modules/effects/src/effect_creator.ts
@@ -15,7 +15,7 @@ type ObservableType<T, OriginalType> = T extends false ? OriginalType : Action;
  * Creates an effect from an `Observable` and an `EffectConfig`.
  *
  * @param source A function which returns an `Observable`.
- * @param config A `Partial<EffectConfig>` to configure the effect.  By default, `dispatch` is true and `resubscribeOnError` is true.
+ * @param config A `Partial<EffectConfig>` to configure the effect.  By default, `dispatch` is true and `useEffectsErrorHandler` is true.
  * @returns If `EffectConfig`#`dispatch` is true, returns `Observable<Action>`.  Else, returns `Observable<unknown>`.
  *
  * @usageNotes

--- a/modules/effects/src/effects_error_handler.ts
+++ b/modules/effects/src/effects_error_handler.ts
@@ -1,0 +1,24 @@
+import { ErrorHandler } from '@angular/core';
+import { Action } from '@ngrx/store';
+import { Observable } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+export type EffectsErrorHandler = <T extends Action>(
+  observable$: Observable<T>,
+  errorHandler: ErrorHandler
+) => Observable<T>;
+
+export const defaultEffectsErrorHandler: EffectsErrorHandler = <
+  T extends Action
+>(
+  observable$: Observable<T>,
+  errorHandler: ErrorHandler
+): Observable<T> => {
+  return observable$.pipe(
+    catchError(error => {
+      if (errorHandler) errorHandler.handleError(error);
+      // Return observable that produces this particular effect
+      return defaultEffectsErrorHandler(observable$, errorHandler);
+    })
+  );
+};

--- a/modules/effects/src/effects_metadata.ts
+++ b/modules/effects/src/effects_metadata.ts
@@ -6,9 +6,9 @@ export function getEffectsMetadata<T>(instance: T): EffectsMetadata<T> {
   return getSourceMetadata(instance).reduce(
     (
       acc: EffectsMetadata<T>,
-      { propertyName, dispatch, resubscribeOnError }
+      { propertyName, dispatch, useEffectsErrorHandler }
     ) => {
-      acc[propertyName] = { dispatch, resubscribeOnError };
+      acc[propertyName] = { dispatch, useEffectsErrorHandler };
       return acc;
     },
     {}

--- a/modules/effects/src/effects_module.ts
+++ b/modules/effects/src/effects_module.ts
@@ -1,16 +1,22 @@
 import {
-  NgModule,
   ModuleWithProviders,
-  Type,
+  NgModule,
   Optional,
   SkipSelf,
+  Type,
 } from '@angular/core';
-import { EffectSources } from './effect_sources';
 import { Actions } from './actions';
-import { ROOT_EFFECTS, FEATURE_EFFECTS, _ROOT_EFFECTS_GUARD } from './tokens';
+import { EffectSources } from './effect_sources';
 import { EffectsFeatureModule } from './effects_feature_module';
+import { defaultEffectsErrorHandler } from './effects_error_handler';
 import { EffectsRootModule } from './effects_root_module';
 import { EffectsRunner } from './effects_runner';
+import {
+  _ROOT_EFFECTS_GUARD,
+  EFFECTS_ERROR_HANDLER,
+  FEATURE_EFFECTS,
+  ROOT_EFFECTS,
+} from './tokens';
 
 @NgModule({})
 export class EffectsModule {
@@ -41,6 +47,10 @@ export class EffectsModule {
           provide: _ROOT_EFFECTS_GUARD,
           useFactory: _provideForRootGuard,
           deps: [[EffectsRunner, new Optional(), new SkipSelf()]],
+        },
+        {
+          provide: EFFECTS_ERROR_HANDLER,
+          useValue: defaultEffectsErrorHandler,
         },
         EffectsRunner,
         EffectSources,

--- a/modules/effects/src/index.ts
+++ b/modules/effects/src/index.ts
@@ -3,6 +3,7 @@ export { EffectConfig } from './models';
 export { Effect } from './effect_decorator';
 export { getEffectsMetadata } from './effects_metadata';
 export { mergeEffects } from './effects_resolver';
+export { EffectsErrorHandler } from './effects_error_handler';
 export { EffectsMetadata, CreateEffectMetadata } from './models';
 export { Actions, ofType } from './actions';
 export { EffectsModule } from './effects_module';
@@ -14,6 +15,7 @@ export {
   rootEffectsInit,
   EffectsRootModule,
 } from './effects_root_module';
+export { EFFECTS_ERROR_HANDLER } from './tokens';
 export { act } from './act';
 export {
   OnIdentifyEffects,

--- a/modules/effects/src/models.ts
+++ b/modules/effects/src/models.ts
@@ -10,12 +10,12 @@ export interface EffectConfig {
   /**
    * Determines if the effect will be resubscribed to if an error occurs in the main actions stream.
    */
-  resubscribeOnError?: boolean;
+  useEffectsErrorHandler?: boolean;
 }
 
 export const DEFAULT_EFFECT_CONFIG: Readonly<Required<EffectConfig>> = {
   dispatch: true,
-  resubscribeOnError: true,
+  useEffectsErrorHandler: true,
 };
 
 export const CREATE_EFFECT_METADATA_KEY = '__@ngrx/effects_create__';

--- a/modules/effects/src/tokens.ts
+++ b/modules/effects/src/tokens.ts
@@ -1,4 +1,5 @@
 import { InjectionToken, Type } from '@angular/core';
+import { EffectsErrorHandler } from './effects_error_handler';
 
 export const _ROOT_EFFECTS_GUARD = new InjectionToken<void>(
   '@ngrx/effects Internal Root Guard'
@@ -11,4 +12,7 @@ export const ROOT_EFFECTS = new InjectionToken<Type<any>[]>(
 );
 export const FEATURE_EFFECTS = new InjectionToken<any[][]>(
   'ngrx/effects: Feature Effects'
+);
+export const EFFECTS_ERROR_HANDLER = new InjectionToken<EffectsErrorHandler>(
+  'ngrx/effects: Effects Error Handler'
 );

--- a/modules/store/testing/src/mock_reducer_manager.ts
+++ b/modules/store/testing/src/mock_reducer_manager.ts
@@ -9,7 +9,7 @@ export class MockReducerManager extends BehaviorSubject<
   constructor() {
     super(() => undefined);
   }
-  
+
   addFeature(feature: any) {
     /* noop */
   }

--- a/projects/example-app/src/app/app.module.ts
+++ b/projects/example-app/src/app/app.module.ts
@@ -15,10 +15,7 @@ import { ROOT_REDUCERS, metaReducers } from '@example-app/reducers';
 
 import { CoreModule } from '@example-app/core';
 import { AppRoutingModule } from '@example-app/app-routing.module';
-import {
-  UserEffects,
-  RouterEffects
-} from '@example-app/core/effects';
+import { UserEffects, RouterEffects } from '@example-app/core/effects';
 import { AppComponent } from '@example-app/core/containers';
 
 @NgModule({


### PR DESCRIPTION
Closes #2294

BREAKING CHANGE:

`resubscribeOnError` renamed to `useEffectsErrorHandler` in `createEffect` metadata

BEFORE:

```ts
  class MyEffects {
    effect$ = createEffect(() => stream$, {
      resubscribeOnError: true, // default
    });
  }
```

AFTER:

```ts
  class MyEffects {
    effect$ = createEffect(() => stream$, {
      useEffectsErrorHandler: true, // default
    });
  }
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
